### PR TITLE
DH1080_comp output not SHA256 hashed

### DIFF
--- a/fish_10/src/dh1080.cpp
+++ b/fish_10/src/dh1080.cpp
@@ -11,7 +11,11 @@ static void DH1080_Base64_Encode(std::string& a_string)
 
 	if(l_b64.find('=') == std::string::npos)
 	{
-		a_string = l_b64 + 'A';
+		//a_string = l_b64 + 'A';
+		a_string = l_b64;
+// cease appending extraneous 'A' to the tail end of priv/pub keys. This isn't needed by mIRC
+// If the above results in multiple '=' being there, which I don't think is the case, then line would possibly end with 0x00 like
+// a_string = l_b64 + 0;
 	}
 	else
 	{

--- a/fish_10/src/dh1080.cpp
+++ b/fish_10/src/dh1080.cpp
@@ -164,7 +164,7 @@ bool DH1080_Generate(std::string& ar_priv, std::string& ar_pub)
 }
 
 
-std::string DH1080_Compute(const std::string& a_priv, const std::string& a_pub)
+std::string DH1080_Compute(const std::string& a_priv, const std::string& a_pub, const std::string& raw_flag)
 {
 	std::string l_result;
 	DH* l_dh;
@@ -189,6 +189,7 @@ std::string DH1080_Compute(const std::string& a_priv, const std::string& a_pub)
 			if(l_remotePubKey && l_pub.size() == 135 &&
 				BN_bin2bn((unsigned char*)l_pub.data(), l_pub.size(), l_remotePubKey))
 			{
+				std::string l_raw(raw_flag);
 				std::vector<char> l_keyBuf;
 				l_keyBuf.resize(DH_size(l_dh), 0);
 
@@ -203,10 +204,16 @@ std::string DH1080_Compute(const std::string& a_priv, const std::string& a_pub)
 
 						memcpy_s(l_paddedBuf.data() + l_paddedBuf.size() - l_keySize, l_paddedBuf.size(), l_keyBuf.data(), l_keySize);
 
+// if 3rd parm == 1, return mime of the 180-byte computed string instead of the SHA256 *of* that string
+// This permits scripts to create key as the 1st 56 or 72 bytes of the mime(SHA512(returned string))
+						if (l_raw == "1") DH1080_Base64_Encode(l_paddedBuf.data());
+						else
 						l_result = DH1080_SHA256(l_paddedBuf.data(), l_paddedBuf.size());
 					}
 					else
 					{
+						if (l_raw == "1") DH1080_Base64_Encode(l_keyBuf.data());
+						else
 						l_result = DH1080_SHA256(l_keyBuf.data(), l_keyBuf.size());
 					}
 				}

--- a/fish_10/src/fish-main.cpp
+++ b/fish_10/src/fish-main.cpp
@@ -650,7 +650,8 @@ MIRC_DLL_EXPORT(DH1080_comp)
 
 		if(l_data.size() >= 2)
 		{
-			const std::string l_shared = DH1080_Compute(l_data[0], l_data[1]);
+			const std::string l_shared = DH1080_Compute(l_data[0], l_data[1], l_data[2]);
+			//support optional 3rd parm 1=mime but do not use sha256() first
 
 			strcpy_s(data, MIRC_PARAM_DATA_LENGTH, l_shared.c_str());
 


### PR DESCRIPTION
Change from
$dll(fish_10.dll,DH1080_comp,privkey pubkey)
to
$dll(fish_10.dll,DH1080_comp,privkey pubkey [1])
where the 3rd parm ="1" returns mime(computed) instead of mime(sha256(computed))