### PR TITLE
Update mircdll.h

### DIFF
--- a/src/mircdll.h
+++ b/src/mircdll.h
@@ -8,6 +8,7 @@ typedef struct {
 	HWND   mHwnd;
 	BOOL   mKeep;
 	BOOL   mUnicode;
+	DWORD  mBeta;
 } LOADINFO;
 
 enum {
@@ -17,7 +18,7 @@ enum {
 	MIRC_RET_DATA_RETURN = 3,
 };
 
-#define MIRC_PARAM_DATA_LENGTH 900
+#define MIRC_PARAM_DATA_LENGTH 8192
 
 #define MIRC_EXPORT_SIG(RET_TYPE) extern "C" RET_TYPE __stdcall
 


### PR DESCRIPTION
Because FiSH now requires minimum v7.56, updating mIRC info as of that version
* LOADINFO structure includes mBeta as of v7.51
* the MIRC_PARAM_DATA_LENGTH value of 900 was increased above 4kb in v6.32, and as of v7.53 this was increased to 8192 along with new identifier $maxlenl (actual max string length including other items was 8192+100)